### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+install:
+  - python setup.py install
+script:
+  - python -m unittest discover .

--- a/README
+++ b/README
@@ -10,6 +10,7 @@ It will take python data structures which can be represented in JSON and convert
 
 This is convenient if you wish to pass structured data around in the URL itself rather than in a POST body.  This may complement a web API which also accepts JSON strings in the body of a POST request, providing equivalent functionality using GET without constructing URLs which include url-encoded json objects.
 
+It has been tested with Python 2.7, 3.3, 3.4 and 3.5.
 
 Usage
 -----

--- a/jsonurl/__init__.py
+++ b/jsonurl/__init__.py
@@ -1,1 +1,3 @@
-from jsonurl import parse_query, query_string, dict_to_args, args_to_dict
+from __future__ import absolute_import
+
+from jsonurl.jsonurl import parse_query, query_string, dict_to_args, args_to_dict

--- a/jsonurl/jsonurl.py
+++ b/jsonurl/jsonurl.py
@@ -4,6 +4,13 @@ import re
 
 from six.moves import range
 
+try:
+    from urllib import quote_plus as quote_plus
+    from urllib import unquote_plus as unquote_plus
+except ImportError:
+    from urllib.parse import quote_plus as quote_plus
+    from urllib.parse import unquote_plus as unquote_plus
+
 def query_string(d):
     args = dict_to_args(d)
     keys = list(args.keys())
@@ -23,10 +30,10 @@ def parse_query(q):
     return args_to_dict(args)
 
 def param_quote(value):
-    return urllib.quote_plus(value)
+    return quote_plus(value)
     
 def param_unquote(value):
-    return urllib.unquote_plus(value)
+    return unquote_plus(value)
 
 def type_cast(value):
     try:

--- a/jsonurl/jsonurl.py
+++ b/jsonurl/jsonurl.py
@@ -2,7 +2,12 @@ from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 import re
 
-from six.moves import range
+try:
+    xrange
+except NameError:
+    pass
+else:
+    range = xrange
 
 try:
     from urllib import quote_plus as quote_plus

--- a/jsonurl/jsonurl.py
+++ b/jsonurl/jsonurl.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import
 import urllib, re
+from six.moves import range
 
 def query_string(d):
     args = dict_to_args(d)
-    keys = args.keys()
+    keys = list(args.keys())
     keys.sort()
     return "&".join([key + "=" + args[key] for key in keys])
 
@@ -39,11 +41,11 @@ def list_to_args(l):
     for i in l:
         if type(i) == dict:
             sub = dict_to_args(i)
-            for s, nv in sub.items():
+            for s, nv in list(sub.items()):
                 args[str(pos) + "." + s] = nv
         elif type(i) == list:
             sub = list_to_args(i)
-            for s, nv in sub.items():
+            for s, nv in list(sub.items()):
                 args[str(pos) + "." + s] = nv
         else:
             args[str(pos)] = param_quote(str(i))
@@ -52,14 +54,14 @@ def list_to_args(l):
 
 def dict_to_args(d):
     args = {}
-    for k, v in d.items():
+    for k, v in list(d.items()):
         if type(v) == dict:
             sub = dict_to_args(v)
-            for s, nv in sub.items():
+            for s, nv in list(sub.items()):
                 args[param_quote(dot_escape(k)) + "." + s] = nv
         elif type(v) == list:
             sub = list_to_args(v)
-            for s, nv in sub.items():
+            for s, nv in list(sub.items()):
                 args[param_quote(dot_escape(k)) + "." + s] = nv
         else:
             args[param_quote(dot_escape(k))] = param_quote(str(v))
@@ -70,7 +72,7 @@ def dot_split(s):
 
 def args_to_dict(args):
     d = {}
-    keys = args.keys()
+    keys = list(args.keys())
     keys.sort()
     
     for arg in keys:
@@ -92,7 +94,7 @@ def args_to_dict(args):
                     next_is_dict = True
             
             if type(ctx) == dict:
-                if not ctx.has_key(bit):
+                if bit not in ctx:
                     if not last:
                         ctx[bit] = {} if next_is_dict else []
                         ctx = ctx[bit]

--- a/jsonurl/jsonurl.py
+++ b/jsonurl/jsonurl.py
@@ -1,5 +1,7 @@
-from __future__ import absolute_import
-import urllib, re
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+import re
+
 from six.moves import range
 
 def query_string(d):

--- a/jsonurl/tests.py
+++ b/jsonurl/tests.py
@@ -4,8 +4,6 @@ from __future__ import (absolute_import, division,
 import unittest
 import jsonurl
 
-from nose.tools import assert_equal
-
 # Functional tests, taken from jsonurl README.
 class TestFlatDictionary(unittest.TestCase):
     @classmethod
@@ -14,7 +12,7 @@ class TestFlatDictionary(unittest.TestCase):
         cls.query_string = jsonurl.query_string(d)
 
     def test_flat_dictionary_to_query_string(self):
-        assert_equal('one=1&two=2', self.query_string)
+        self.assertEqual('one=1&two=2', self.query_string)
 
 
 class TestNestedDictionary(unittest.TestCase):
@@ -26,14 +24,14 @@ class TestNestedDictionary(unittest.TestCase):
         cls.parsed_query = jsonurl.parse_query(cls.query_string)
 
     def test_nested_dictionary_to_query_string(self):
-        assert_equal('four=4&one.three=3&one.two=2', self.query_string)
+        self.assertEqual('four=4&one.three=3&one.two=2', self.query_string)
 
     def test_nested_dictionary_to_args(self):
-        assert_equal({'four': '4', 'one.three': '3', 'one.two': '2'},
+        self.assertEqual({'four': '4', 'one.three': '3', 'one.two': '2'},
                      self.args)
 
     def test_parse_nested_dictionary_query(self):
-        assert_equal(self.d, self.parsed_query)
+        self.assertEqual(self.d, self.parsed_query)
 
 
 class TestNestedList(unittest.TestCase):
@@ -45,14 +43,14 @@ class TestNestedList(unittest.TestCase):
         cls.parsed_query = jsonurl.parse_query(cls.query_string)
 
     def test_nested_list_to_query_string(self):
-        assert_equal('one=1&two.0=2&two.1=3&two.2=4', self.query_string)
+        self.assertEqual('one=1&two.0=2&two.1=3&two.2=4', self.query_string)
 
     def test_nested_list_to_args(self):
-        assert_equal({'two.1': '3', 'two.0': '2', 'two.2': '4', 'one': '1'},
+        self.assertEqual({'two.1': '3', 'two.0': '2', 'two.2': '4', 'one': '1'},
                      self.args)
     
     def test_parse_nested_list_query(self):
-        assert_equal(self.d, self.parsed_query)
+        self.assertEqual(self.d, self.parsed_query)
 
 
 class TestListInDictionary(unittest.TestCase):
@@ -62,7 +60,7 @@ class TestListInDictionary(unittest.TestCase):
         cls.query_string = jsonurl.query_string(d)
 
     def test_list_in_dictionary_to_query_string(self):
-        assert_equal('one.0.three=3&one.0.two=2&one.1=4', self.query_string)
+        self.assertEqual('one.0.three=3&one.0.two=2&one.1=4', self.query_string)
 
 
 class TestUrlEscaping(unittest.TestCase):
@@ -73,10 +71,10 @@ class TestUrlEscaping(unittest.TestCase):
         cls.parsed_query = jsonurl.parse_query(cls.query_string)
 
     def test_query_string_escaping(self):
-        assert_equal('escape_me=I%27ll+need+escaping', self.query_string)
+        self.assertEqual('escape_me=I%27ll+need+escaping', self.query_string)
 
     def test_parse_escaped_query_string(self):
-        assert_equal(self.d, self.parsed_query)
+        self.assertEqual(self.d, self.parsed_query)
 
 
 class TestDotEscaping(unittest.TestCase):
@@ -87,7 +85,7 @@ class TestDotEscaping(unittest.TestCase):
         cls.parsed_query = jsonurl.parse_query(cls.query_string)
 
     def test_dot_escaping(self):
-        assert_equal(self.d, self.parsed_query)
+        self.assertEqual(self.d, self.parsed_query)
 
 
 class TestParameterOrdering(unittest.TestCase):
@@ -97,4 +95,4 @@ class TestParameterOrdering(unittest.TestCase):
         cls.query_string = jsonurl.query_string(d)
 
     def test_parameter_ordering(self):
-        assert_equal('a.0=1&a.1=2&a.2=3&b=last', self.query_string)
+        self.assertEqual('a.0=1&a.1=2&a.2=3&b=last', self.query_string)

--- a/jsonurl/tests.py
+++ b/jsonurl/tests.py
@@ -1,0 +1,100 @@
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals) 
+
+import unittest
+import jsonurl
+
+from nose.tools import assert_equal
+
+# Functional tests, taken from jsonurl README.
+class TestFlatDictionary(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        d = {"one": 1, "two": 2}
+        cls.query_string = jsonurl.query_string(d)
+
+    def test_flat_dictionary_to_query_string(self):
+        assert_equal('one=1&two=2', self.query_string)
+
+
+class TestNestedDictionary(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = {"one": {"two": 2, "three": 3}, "four": 4}
+        cls.query_string = jsonurl.query_string(cls.d)
+        cls.args = jsonurl.dict_to_args(cls.d)
+        cls.parsed_query = jsonurl.parse_query(cls.query_string)
+
+    def test_nested_dictionary_to_query_string(self):
+        assert_equal('four=4&one.three=3&one.two=2', self.query_string)
+
+    def test_nested_dictionary_to_args(self):
+        assert_equal({'four': '4', 'one.three': '3', 'one.two': '2'},
+                     self.args)
+
+    def test_parse_nested_dictionary_query(self):
+        assert_equal(self.d, self.parsed_query)
+
+
+class TestNestedList(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = {"one": 1, "two": [2, 3, 4]}
+        cls.query_string = jsonurl.query_string(cls.d)
+        cls.args = jsonurl.dict_to_args(cls.d)
+        cls.parsed_query = jsonurl.parse_query(cls.query_string)
+
+    def test_nested_list_to_query_string(self):
+        assert_equal('one=1&two.0=2&two.1=3&two.2=4', self.query_string)
+
+    def test_nested_list_to_args(self):
+        assert_equal({'two.1': '3', 'two.0': '2', 'two.2': '4', 'one': '1'},
+                     self.args)
+    
+    def test_parse_nested_list_query(self):
+        assert_equal(self.d, self.parsed_query)
+
+
+class TestListInDictionary(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        d = {"one" : [ {"two" : 2, "three" : 3}, 4 ]}
+        cls.query_string = jsonurl.query_string(d)
+
+    def test_list_in_dictionary_to_query_string(self):
+        assert_equal('one.0.three=3&one.0.two=2&one.1=4', self.query_string)
+
+
+class TestUrlEscaping(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = {"escape_me" : "I'll need escaping"}
+        cls.query_string = jsonurl.query_string(cls.d)
+        cls.parsed_query = jsonurl.parse_query(cls.query_string)
+
+    def test_query_string_escaping(self):
+        assert_equal('escape_me=I%27ll+need+escaping', self.query_string)
+
+    def test_parse_escaped_query_string(self):
+        assert_equal(self.d, self.parsed_query)
+
+
+class TestDotEscaping(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = {"user.names" : ["richard", "jones"]}
+        cls.query_string = jsonurl.query_string(cls.d)
+        cls.parsed_query = jsonurl.parse_query(cls.query_string)
+
+    def test_dot_escaping(self):
+        assert_equal(self.d, self.parsed_query)
+
+
+class TestParameterOrdering(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        d = {"b": "last", "a": [1, 2, 3]}
+        cls.query_string = jsonurl.query_string(d)
+
+    def test_parameter_ordering(self):
+        assert_equal('a.0=1&a.1=2&a.2=3&b=last', self.query_string)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,11 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python 2',
+        'Programming Language :: Python 2.7',
+        'Programming Language :: Python 3.3',
+        'Programming Language :: Python 3.4',
+        'Programming Language :: Python 3.5',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'jsonurl',
-    version = '1.0.0',
+    version = '1.1.0',
     packages = find_packages(),
     install_requires = [],
     url = '',


### PR DESCRIPTION
Adds tests from the README, Travis CI, makes Python 2.7 and 3
cross-compatible and bump the version to 1.1.0.

Tested on Python 2.7, 3.3, 3.4 and 3.5.

(Automated testing for < 2.7 would introduce other dependencies as
unittest discover isn't available before that. However, the code may well work,
as it may well also on the other Python 3.x versions.)

The Travis builds pass on my fork.
